### PR TITLE
Modify JWT token claim for push authentication

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.push.servlet/src/main/java/org/wso2/carbon/identity/local/auth/push/servlet/constant/PushServletConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.servlet/src/main/java/org/wso2/carbon/identity/local/auth/push/servlet/constant/PushServletConstants.java
@@ -31,7 +31,7 @@ public class PushServletConstants {
     public static final String AUTH_RESPONSE = "authResponse";
 
     public static final String TOKEN_DEVICE_ID = "deviceId";
-    public static final String TOKEN_PUSH_AUTH_ID = "pushId";
+    public static final String TOKEN_PUSH_AUTH_ID = "pushAuthId";
     public static final String TOKEN_TENANT_DOMAIN = "tenantDomain";
 
     /**


### PR DESCRIPTION
Change the push auth identifier claim name from pushId to pushAuthId in the JWT token for push authentication