### PR TITLE
Conditionally add number challenge value into push notification data

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
@@ -424,7 +424,7 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
             }
 
             // If the code reaches this point, the user has a device registered.
-            prepareAuthChallenges(pushAuthContext);
+            prepareAuthChallenges(pushAuthContext, tenantDomain);
             pushAuthContext.setDeviceId(device.getDeviceId());
             pushAuthContext.setScenario(PUSH_AUTHENTICATION.getValue());
             pushAuthContextManager.storeContext(pushAuthId, pushAuthContext);
@@ -1497,14 +1497,19 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
      * Prepare the challenges related to push authentication.
      *
      * @param pushAuthContext PushAuthContext.
+     * @param tenantDomain    Tenant domain.
+     * @throws AuthenticationFailedException If an error occurred while preparing the challenges.
      */
-    private void prepareAuthChallenges(PushAuthContext pushAuthContext) {
+    private void prepareAuthChallenges(PushAuthContext pushAuthContext, String tenantDomain)
+            throws AuthenticationFailedException {
 
         String challenge = UUID.randomUUID().toString();
         pushAuthContext.setChallenge(challenge);
-        Random random = new Random();
-        int numberChallenge = random.nextInt(100);
-        pushAuthContext.setNumberChallenge(Integer.toString(numberChallenge));
+        if (isNumberChallengeEnabled(tenantDomain)) {
+            Random random = new Random();
+            int numberChallenge = random.nextInt(100);
+            pushAuthContext.setNumberChallenge(Integer.toString(numberChallenge));
+        }
     }
 
     /**


### PR DESCRIPTION
Regardless of number challenge feature is enabled or disabled for push authenticator, a number challenge value is being sent in the push notification data. With this PR, we restrict that behaviour only for number challenge enabled scenario only.

Related issue:
- https://github.com/wso2/product-is/issues/23860