### PR TITLE
Add deviceHandle and userId to PushAuthenticator event meta properties

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
@@ -106,6 +106,7 @@ import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.Au
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ConnectorConfig.ENABLE_PUSH_DEVICE_PROGRESSIVE_ENROLLMENT;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ConnectorConfig.ENABLE_PUSH_NUMBER_CHALLENGE;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ConnectorConfig.RESEND_NOTIFICATION_MAX_ATTEMPTS;
+import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.DEVICE_HANDLE;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.DEVICE_ID;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.DEVICE_TOKEN;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ENROLL_DATA_PARAM;
@@ -1648,6 +1649,7 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
         metaProperties.put(DEVICE_TOKEN, device.getDeviceToken());
         metaProperties.put(NOTIFICATION_PROVIDER, device.getProvider());
         metaProperties.put(DEVICE_ID, device.getDeviceId());
+        metaProperties.put(DEVICE_HANDLE, device.getDeviceHandle());
 
         metaProperties.put(CHALLENGE, pushAuthContext.getChallenge());
         metaProperties.put(NUMBER_CHALLENGE, pushAuthContext.getNumberChallenge());

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
@@ -1695,6 +1695,16 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
                                 Map<String, Object> eventProperties) throws IdentityEventException {
 
         HashMap<String, Object> properties = new HashMap<>();
+
+        String userId = null;
+        try {
+            userId = user.getUserId();
+        } catch (UserIdNotFoundException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(e.getMessage(), e);
+            }
+        }
+        properties.put(IdentityEventConstants.EventProperty.USER_ID, userId);
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
         properties.put(TENANT_DOMAIN, user.getTenantDomain());

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/constant/AuthenticatorConstants.java
@@ -44,6 +44,7 @@ public class AuthenticatorConstants {
     public static final String REQUEST_DEVICE_OS = "deviceOS";
     public static final String REQUEST_DEVICE_BROWSER = "browser";
     public static final String DEVICE_ID = "deviceId";
+    public static final String DEVICE_HANDLE = "deviceHandle";
     public static final String PUSH_AUH_USER_CONSENT = "pushAuthUserConsent";
     public static final String AUTHENTICATOR_MESSAGE = "authenticatorMessage";
     public static final String PUSH_NOTIFICATION_SENT = "PushNotificationSent";

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/constant/AuthenticatorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticatorTest.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
@@ -315,9 +316,34 @@ public class PushAuthenticatorTest {
     public void testTriggerEvent() throws IdentityEventException {
 
         AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserId("testUserId");
         user.setUserName("testUser");
         user.setUserStoreDomain("PRIMARY");
         user.setTenantDomain("carbon.super");
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put("key1", "value1");
+
+        try (MockedStatic<AuthenticatorDataHolder> mockedDataHolder = mockStatic(AuthenticatorDataHolder.class)) {
+            IdentityEventService identityEventService = mock(IdentityEventService.class);
+            AuthenticatorDataHolder dataHolder = mock(AuthenticatorDataHolder.class);
+            mockedDataHolder.when(AuthenticatorDataHolder::getInstance).thenReturn(dataHolder);
+            when(dataHolder.getIdentityEventService()).thenReturn(identityEventService);
+
+            pushAuthenticator.triggerEvent("TEST_EVENT", user, eventProperties);
+
+            verify(identityEventService, times(1)).handleEvent(any(Event.class));
+        }
+    }
+
+    @Test
+    public void testTriggerEventWithoutUserId() throws IdentityEventException, UserIdNotFoundException {
+
+        AuthenticatedUser user = mock(AuthenticatedUser.class);
+        when(user.getUserName()).thenReturn("testUser");
+        when(user.getUserStoreDomain()).thenReturn("PRIMARY");
+        when(user.getTenantDomain()).thenReturn("carbon.super");
+        when(user.getUserId()).thenThrow(new UserIdNotFoundException("User ID not found"));
 
         Map<String, Object> eventProperties = new HashMap<>();
         eventProperties.put("key1", "value1");


### PR DESCRIPTION
## Purpose
Include device handle information in push authentication metadata so that push notification provider can access that data at notification send time.

## Goals
- Add `DEVICE_HANDLE` constant to the authenticator constants.
- Update `PushAuthenticator` to include device handle in the metadata properties propagated during authentication flow.
- Ensure device handle is available in subsequent authorization and device management operations.

## GitHub Issue
- https://github.com/wso2/product-is/issues/26739

## Related PRs

1. identity-local-auth-push (this PR): https://github.com/wso2-extensions/identity-local-auth-push/pull/19
2. identity-notification-push: https://github.com/wso2-extensions/identity-notification-push/pull/18
3. identity-api-user: https://github.com/wso2/identity-api-user/pull/282
4. identity-event-handler-notification: https://github.com/wso2-extensions/identity-event-handler-notification/pull/365
5. identity-notification-push: https://github.com/wso2-extensions/identity-notification-push/pull/19
6. identity-api-server: https://github.com/wso2/identity-api-server/pull/1070

## Approach
This change adds deviceHandle data to the push authenticator's metaProperties.

- Constants
  - Added `DEVICE_HANDLE` constant in `AuthenticatorConstants.java` to represent the device handle key in metaProperties.

- Authenticator
  - `PushAuthenticator.java`: Updated to include `device.getDeviceHandle()` in the metadata properties map alongside existing device metadata (device ID, token, provider).
  - This ensures the device handle is available throughout the authentication context and accessible to subsequent components in the authentication flow.

The device handle is retrieved from the `Device` object returned by the push provider during authentication and is now propagated for use in device management and tracking operations.

## User stories
- As an authentication component, I can add deviceHandle to push authentication metaProperties so push provider can use it to send notification.

## Release note
Push authenticator now includes deviceHandle meta property to authentication push notification event. This enables push provider to retrieve deviceHandle at notification send time.

## Documentation
N/A - Internal implementation change to add device handle tracking. No end-user documentation impact.

## Training
N/A - No training content required; this is an internal enhancement.

## Certification
N/A - No certification impact.

## Marketing
N/A - Internal improvement without marketing implications.

## Automation tests
 - Unit tests
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A - No sample apps affected. This is an internal authenticator enhancement.

## Migrations (if applicable)
No migration required. Device handle support is additive; existing authentication flows continue to work unchanged.
 