### PR TITLE
Fix App native flow when no device found for the authenticating user

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
@@ -152,6 +152,7 @@ import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.Au
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.IDF_HANDLER_NAME;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.INVALID_USERNAME;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.IP_ADDRESS;
+import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.IS_API_BASED_AND_NO_DEVICE_ENROLLED;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.IS_DEVICE_REGISTRATION_ENGAGED;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.IS_LOGIN_ATTEMPT_BY_INVALID_USER;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.LOCAL_AUTHENTICATOR;
@@ -427,6 +428,18 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
 
             // If device is null, that means the user does not have a device registered.
             if (device == null) {
+
+                // If API based authentication, return an error response.
+                if (isAPIBasedAuthRequest(request)) {
+                    // App native does not support progressive device enrollment.
+                    // TODO: We can remove this check once app native supports progressive device enrollment.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("API based authentication request with no device registered. " +
+                                "Failing authentication.");
+                    }
+                    context.setProperty(IS_API_BASED_AND_NO_DEVICE_ENROLLED, true);
+                    handlePushAuthFailedScenario(request, response, context, ERROR_USER_REGISTERED_DEVICE_NOT_FOUND);
+                }
 
                 // Check if push device progressive enrollment is enabled.
                 if (!isProgressiveDeviceEnrollmentEnabled(tenantDomain)) {
@@ -782,6 +795,12 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
 
         List<AuthenticatorParamMetadata> authenticatorParamMetadataList = new ArrayList<>();
         authenticatorData.setAuthParams(authenticatorParamMetadataList);
+
+        if (Boolean.TRUE.equals(context.getProperty(IS_API_BASED_AND_NO_DEVICE_ENROLLED))) {
+            /* No need to add required params and additional data as authentication will be failed with an error
+            message mentioning no device enrolled. */
+            return Optional.of(authenticatorData);
+        }
 
         // To show additional data, it requires at least one required param. So we have added scenario as required
         // param. To continue the push flow, the scenario should be PROCEED_PUSH_AUTHENTICATION.
@@ -1826,4 +1845,14 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
         }
     }
 
+    /**
+     * Check whether the request is coming for an API based authentication flow.
+     *
+     * @param request HttpServletRequest.
+     * @return True if the request is coming for an API based authentication flow, false otherwise.
+     */
+    private boolean isAPIBasedAuthRequest(HttpServletRequest request) {
+
+        return Boolean.TRUE.equals(request.getAttribute(FrameworkConstants.IS_API_BASED_AUTH_FLOW));
+    }
 }

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/constant/AuthenticatorConstants.java
@@ -104,6 +104,7 @@ public class AuthenticatorConstants {
             "the push authentication request";
     public static final String PUSH_AUTH_FAIL_TOKEN_RESPONSE_FAILED = "Token response validation failed for " +
             "the push authentication request";
+    public static final String IS_API_BASED_AND_NO_DEVICE_ENROLLED = "isApiBasedAndNoDeviceEnrolled";
 
     private AuthenticatorConstants() {
 

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticatorTest.java
@@ -64,6 +64,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator.SKIP_RETRY_FROM_AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTH_ERROR_MSG;
@@ -71,6 +72,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ConnectorConfig.ENABLE_PUSH_DEVICE_PROGRESSIVE_ENROLLMENT;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ConnectorConfig.ENABLE_PUSH_NUMBER_CHALLENGE;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ErrorMessages.ERROR_CODE_PUSH_AUTH_ID_NOT_FOUND;
+import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.IS_API_BASED_AND_NO_DEVICE_ENROLLED;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.PUSH_AUTHENTICATOR_FRIENDLY_NAME;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.PUSH_AUTHENTICATOR_I18_KEY;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.PUSH_AUTHENTICATOR_NAME;
@@ -376,4 +378,25 @@ public class PushAuthenticatorTest {
             assertTrue(result);
         }
     }
+
+    @Test
+    public void testGetAuthInitiationDataWhenApiBasedAndNoDeviceEnrolled() throws AuthenticationFailedException {
+
+        ExternalIdPConfig externalIdPConfig = mock(ExternalIdPConfig.class);
+        when(context.getExternalIdP()).thenReturn(externalIdPConfig);
+        when(externalIdPConfig.getIdPName()).thenReturn("externalIdP");
+        when(context.getProperty(IS_API_BASED_AND_NO_DEVICE_ENROLLED)).thenReturn(true);
+
+        Optional<AuthenticatorData> result = pushAuthenticator.getAuthInitiationData(context);
+
+        assertTrue(result.isPresent());
+        AuthenticatorData data = result.get();
+        assertEquals(PUSH_AUTHENTICATOR_NAME, data.getName());
+        assertEquals(PUSH_AUTHENTICATOR_FRIENDLY_NAME, data.getDisplayName());
+        assertEquals("externalIdP", data.getIdp());
+        assertEquals(PUSH_AUTHENTICATOR_I18_KEY, data.getI18nKey());
+        assertEquals(INTERNAL_PROMPT, data.getPromptType());
+        assertNull(data.getAdditionalData());
+    }
+
 }


### PR DESCRIPTION
This pull request introduces a new handling mechanism for API-based authentication requests when no device is enrolled, ensuring that such requests fail gracefully and return an appropriate error response. The changes also include the addition of a new constant, updates to the authentication logic, and corresponding unit tests.

Related issue:
- https://github.com/wso2/product-is/issues/26924

### API-based authentication flow handling

* Added a check in `PushAuthenticator.java` to detect API-based authentication requests with no device enrolled, and immediately fail authentication with a specific error response.
* Introduced the `IS_API_BASED_AND_NO_DEVICE_ENROLLED` constant in `AuthenticatorConstants.java` to track this scenario in the authentication context.
* Implemented the `isAPIBasedAuthRequest` method to determine if a request is API-based, using the `FrameworkConstants.IS_API_BASED_AUTH_FLOW` attribute.

### Authentication initiation data

* Modified `getAuthInitiationData` to return early without additional parameters or data if the API-based and no device enrolled flag is set, ensuring error messaging is consistent.

### Unit testing

* Added a unit test in `PushAuthenticatorTest.java` to verify that `getAuthInitiationData` behaves correctly when API-based authentication is attempted with no device enrolled.