### PR TITLE
Fix first factor authentication issue with App native authentication

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticator.java
@@ -109,6 +109,7 @@ import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.Au
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.DEVICE_HANDLE;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.DEVICE_ID;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.DEVICE_TOKEN;
+import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.DISPLAY_USERNAME;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ENROLL_DATA_PARAM;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ERROR_NUMBER_CHALLENGE_FAILED_QUERY_PARAMS;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ERROR_PUSH_AUTHENTICATION_FAILED;
@@ -195,6 +196,7 @@ import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.Au
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.UNLOCK_QUERY_PARAM;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.USERNAME;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.USERNAME_PARAM;
+import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.USERNAME_PARAM_KEY;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.USER_AGENT;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.util.AuthenticatorUtils.getPushAuthPErrorPageUrl;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.util.AuthenticatorUtils.getPushAuthWaitPageUrl;
@@ -792,10 +794,22 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
         authenticatorData.setIdp(idpName);
         authenticatorData.setI18nKey(PUSH_AUTHENTICATOR_I18_KEY);
 
-        authenticatorData.setPromptType(FrameworkConstants.AuthenticatorPromptType.INTERNAL_PROMPT);
-
         List<AuthenticatorParamMetadata> authenticatorParamMetadataList = new ArrayList<>();
+        List<String> requiredParams = new ArrayList<>();
+        if (authenticatedUser == null) {
+            AuthenticatorParamMetadata usernameMetadata = new AuthenticatorParamMetadata(
+                    USERNAME, DISPLAY_USERNAME, FrameworkConstants.AuthenticatorParamType.STRING,
+                    0, Boolean.FALSE, USERNAME_PARAM_KEY);
+            authenticatorParamMetadataList.add(usernameMetadata);
+            requiredParams.add(USERNAME);
+            authenticatorData.setRequiredParams(requiredParams);
+            authenticatorData.setAuthParams(authenticatorParamMetadataList);
+            authenticatorData.setPromptType(FrameworkConstants.AuthenticatorPromptType.USER_PROMPT);
+            return Optional.of(authenticatorData);
+        }
+
         authenticatorData.setAuthParams(authenticatorParamMetadataList);
+        authenticatorData.setPromptType(FrameworkConstants.AuthenticatorPromptType.INTERNAL_PROMPT);
 
         if (Boolean.TRUE.equals(context.getProperty(IS_API_BASED_AND_NO_DEVICE_ENROLLED))) {
             /* No need to add required params and additional data as authentication will be failed with an error
@@ -805,7 +819,6 @@ public class PushAuthenticator extends AbstractApplicationAuthenticator implemen
 
         // To show additional data, it requires at least one required param. So we have added scenario as required
         // param. To continue the push flow, the scenario should be PROCEED_PUSH_AUTHENTICATION.
-        List<String> requiredParams = new ArrayList<>();
         requiredParams.add(SCENARIO);
         authenticatorData.setRequiredParams(requiredParams);
 

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/push/authenticator/constant/AuthenticatorConstants.java
@@ -28,6 +28,8 @@ public class AuthenticatorConstants {
     public static final String PUSH_AUTHENTICATOR_I18_KEY = "authenticator.push.notification";
     public static final String PUSH_AUTHENTICATOR_ERROR_PREFIX = "PNA";
     public static final String USERNAME = "username";
+    public static final String DISPLAY_USERNAME = "Username";
+    public static final String USERNAME_PARAM_KEY = "username.param";
     public static final String PASSWORD = "password";
     public static final String AUTHENTICATORS = "authenticators=";
     public static final String IDF_HANDLER_NAME = "IdentifierExecutor";

--- a/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.push.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/push/authenticator/PushAuthenticatorTest.java
@@ -70,6 +70,7 @@ import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator.SKIP_RETRY_FROM_AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTH_ERROR_MSG;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AuthenticatorPromptType.INTERNAL_PROMPT;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AuthenticatorPromptType.USER_PROMPT;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ConnectorConfig.ENABLE_PUSH_DEVICE_PROGRESSIVE_ENROLLMENT;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ConnectorConfig.ENABLE_PUSH_NUMBER_CHALLENGE;
 import static org.wso2.carbon.identity.local.auth.push.authenticator.constant.AuthenticatorConstants.ErrorMessages.ERROR_CODE_PUSH_AUTH_ID_NOT_FOUND;
@@ -216,6 +217,10 @@ public class PushAuthenticatorTest {
         ExternalIdPConfig externalIdPConfig = mock(ExternalIdPConfig.class);
         when(context.getExternalIdP()).thenReturn(externalIdPConfig);
         when(externalIdPConfig.getIdPName()).thenReturn("externalIdP");
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName("testUser");
+        when(context.getLastAuthenticatedUser()).thenReturn(authenticatedUser);
 
         when(context.getProperty(PUSH_AUTH_ID)).thenReturn(new Object());
         when(context.getProperty(PUSH_AUTH_ID).toString()).thenReturn("samplePushAuthId");
@@ -406,11 +411,38 @@ public class PushAuthenticatorTest {
     }
 
     @Test
+    public void testGetAuthInitiationDataWhenNoAuthenticatedUser() throws AuthenticationFailedException {
+
+        ExternalIdPConfig externalIdPConfig = mock(ExternalIdPConfig.class);
+        when(context.getExternalIdP()).thenReturn(externalIdPConfig);
+        when(externalIdPConfig.getIdPName()).thenReturn("externalIdP");
+        when(context.getLastAuthenticatedUser()).thenReturn(null);
+
+        Optional<AuthenticatorData> result = pushAuthenticator.getAuthInitiationData(context);
+
+        assertTrue(result.isPresent());
+        AuthenticatorData data = result.get();
+        assertEquals(PUSH_AUTHENTICATOR_NAME, data.getName());
+        assertEquals(PUSH_AUTHENTICATOR_FRIENDLY_NAME, data.getDisplayName());
+        assertEquals("externalIdP", data.getIdp());
+        assertEquals(PUSH_AUTHENTICATOR_I18_KEY, data.getI18nKey());
+        assertEquals(USER_PROMPT, data.getPromptType());
+        assertNotNull(data.getAuthParams());
+        assertNotNull(data.getRequiredParams());
+        assertEquals(USERNAME, data.getRequiredParams().get(0));
+    }
+
+    @Test
     public void testGetAuthInitiationDataWhenApiBasedAndNoDeviceEnrolled() throws AuthenticationFailedException {
 
         ExternalIdPConfig externalIdPConfig = mock(ExternalIdPConfig.class);
         when(context.getExternalIdP()).thenReturn(externalIdPConfig);
         when(externalIdPConfig.getIdPName()).thenReturn("externalIdP");
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName("testUser");
+        when(context.getLastAuthenticatedUser()).thenReturn(authenticatedUser);
+
         when(context.getProperty(IS_API_BASED_AND_NO_DEVICE_ENROLLED)).thenReturn(true);
 
         Optional<AuthenticatorData> result = pushAuthenticator.getAuthInitiationData(context);


### PR DESCRIPTION
This pull request updates the Push Authenticator to improve how it handles authentication initiation when there is no authenticated user. Specifically, it ensures the authenticator prompts for the username when needed and includes related metadata. It also introduces new constants and corresponding unit tests to verify this behavior.

**Enhancements to authentication initiation:**

* Updated `PushAuthenticator.java` so that if there is no authenticated user, the authenticator now prompts for the username by setting the prompt type to `USER_PROMPT`, adding the username as a required parameter, and including relevant parameter metadata.
* Added new constants `DISPLAY_USERNAME` and `USERNAME_PARAM_KEY` to `AuthenticatorConstants.java` for improved metadata handling.
* Adjusted import statements to include the new constants where necessary. [[1]](diffhunk://#diff-e518397bf9178049fb43d6408980da3902f9316045ba52a05a1213437b26f426R112) [[2]](diffhunk://#diff-e518397bf9178049fb43d6408980da3902f9316045ba52a05a1213437b26f426R199)

**Testing improvements:**

* Added a new unit test in `PushAuthenticatorTest.java` to verify that the authenticator correctly prompts for the username when there is no authenticated user.
* Updated existing tests to mock an authenticated user where appropriate, ensuring comprehensive coverage of both scenarios.

**Code maintenance:**

* Minor refactoring to remove redundant initialization of `requiredParams` and to ensure correct assignment based on authentication context.